### PR TITLE
Retreat from test_serialize_netcdf()

### DIFF
--- a/tiled/_tests/test_xarray.py
+++ b/tiled/_tests/test_xarray.py
@@ -1,5 +1,3 @@
-from io import BytesIO
-
 import dask.array
 import numpy
 import orjson
@@ -11,7 +9,7 @@ from ..adapters.mapping import MapAdapter
 from ..adapters.xarray import DatasetAdapter
 from ..client import Context, from_context, record_history
 from ..client import xarray as xarray_client
-from ..serialization.xarray import serialize_json, serialize_netcdf
+from ..serialization.xarray import serialize_json
 from ..server.app import build_app
 
 image = numpy.random.random((3, 5))
@@ -165,20 +163,3 @@ async def test_serialize_json(ds_node: DatasetAdapter):
     ds_coords_and_vars = set(ds_node)
 
     assert set(result_data_keys).issubset(ds_coords_and_vars)
-
-
-@pytest.mark.parametrize("ds_node", tree.values(), ids=tree.keys())
-# Suppress warning from tiled.serialization.xarray._BytesIOThatIgnoresClose.close()
-@pytest.mark.filterwarnings("ignore:Exception ignored in")
-@pytest.mark.asyncio
-async def test_serialize_netcdf(ds_node: DatasetAdapter):
-    """Verify that Dataset serialized as netCDF can be reconstituted."""
-    metadata = None  # Not used
-    filter_for_access = None  # Not used
-    bytes_ = await serialize_netcdf(ds_node, metadata, filter_for_access)
-    byte_stream = BytesIO(bytes_)
-
-    result = xarray.open_dataset(byte_stream, engine="scipy")
-    expected = ds_node
-
-    assert result == expected

--- a/tiled/serialization/xarray.py
+++ b/tiled/serialization/xarray.py
@@ -56,8 +56,8 @@ if modules_available("scipy"):
         file = _BytesIOThatIgnoresClose()
         # Per the xarray.Dataset.to_netcdf documentation,
         # file-like objects are only supported by the scipy engine.
-        bytes_ = (await as_dataset(node)).to_netcdf(file, engine="scipy")
-        return bytes_
+        (await as_dataset(node)).to_netcdf(file, engine="scipy")
+        return file.getbuffer()
 
 
 # Support DataFrame formats by first converting to DataFrame.


### PR DESCRIPTION
This is the strategic retreat mentioned here: https://github.com/bluesky/tiled/pull/560#issuecomment-1706666451.